### PR TITLE
The primary change involves modifying the behavior of a mocked cache …

### DIFF
--- a/test/EasyKeys.Extensions.Dapper.UnitTest/Repositories/DapperRepositoryCacheTests.cs
+++ b/test/EasyKeys.Extensions.Dapper.UnitTest/Repositories/DapperRepositoryCacheTests.cs
@@ -158,7 +158,7 @@ public class DapperRepositoryCacheTests
             x => x.GetAsync(
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>())).
-            ReturnsAsync(data).
+            ReturnsAsync(default(byte[])).
             Verifiable();
 
         mockCmdExe.Setup(x => x.ExecuteAsync(


### PR DESCRIPTION
…setup in the `DapperRepositoryCacheTests` class, specifically within the `DapperRepositoryCacheTests.cs` file. This adjustment is focused on altering the return value of the `GetAsync` method from a predefined `data` object to a default `byte[]` (byte array) when called asynchronously. This change is likely aimed at creating test conditions that simulate a scenario where the cache does not have the expected data, effectively testing how the system handles a cache miss.

### List of Changes:
- **Modification in Mocked Cache Setup**: In the `DapperRepositoryCacheTests` class, the setup of a mocked cache has been changed. Previously, the mock was configured to return a specific `data` object asynchronously upon calling its `GetAsync` method. The new setup now returns a default `byte[]` asynchronously instead, which is intended to simulate a cache miss scenario by indicating that the expected data is not present in the cache.

_Reference_: `DapperRepositoryCacheTests.cs` - Adjusted the behavior of the mocked cache setup in the `GetAsync` method to return a default `byte[]`.